### PR TITLE
Utilize active record lazy loading

### DIFF
--- a/lib/active_record_simple_execute.rb
+++ b/lib/active_record_simple_execute.rb
@@ -1,34 +1,36 @@
 require "active_record_simple_execute/version"
 
-require "active_record"
+require "active_support/lazy_load_hooks"
 
-ActiveRecord::Base.class_eval do
+ActiveSupport.on_load(:active_record) do
 
-  def self.simple_execute(sql_str, **sql_vars)
-    ### must use send because this method is private is Rails 5.1 only, Public in 5.0 and 5.2
-    sanitized_sql = ActiveRecord::Base.send(:sanitize_sql_array, [sql_str, **sql_vars])
+  ActiveRecord::Base.class_eval do
+    def self.simple_execute(sql_str, **sql_vars)
+      ### must use send because this method is private is Rails 5.1 only, Public in 5.0 and 5.2
+      sanitized_sql = ActiveRecord::Base.send(:sanitize_sql_array, [sql_str, **sql_vars])
 
-    results = ActiveRecord::Base.connection.execute(sanitized_sql)
+      results = ActiveRecord::Base.connection.execute(sanitized_sql)
 
-    if defined?(PG::Result) && results.is_a?(PG::Result)
-      records = results.to_a
-    elsif defined?(Mysql2::Result) && results.is_a?(Mysql2::Result)
-      records = []
+      if defined?(PG::Result) && results.is_a?(PG::Result)
+        records = results.to_a
+      elsif defined?(Mysql2::Result) && results.is_a?(Mysql2::Result)
+        records = []
 
-      results.each do |row|
-        h = {}
+        results.each do |row|
+          h = {}
 
-        results.fields.each_with_index do |field,i|
-          h[field] = row[i]
+          results.fields.each_with_index do |field,i|
+            h[field] = row[i]
+          end
+
+          records << h
         end
-
-        records << h
+      else
+        records = results
       end
-    else
-      records = results
-    end
 
-    return records
+      return records
+    end
   end
 
 end


### PR DESCRIPTION
Currently the gem is loaded right away and requires active_record. When this happens, the database configuration is required even to run basic tasks like assets:precompile, which is suboptimal. 

Instead we can utilize lazy loading for active record as is standard with activerecord gems/plugins.