### PR TITLE
Allow vargs and kwargs

### DIFF
--- a/lib/active_record_simple_execute.rb
+++ b/lib/active_record_simple_execute.rb
@@ -5,9 +5,13 @@ require "active_support/lazy_load_hooks"
 ActiveSupport.on_load(:active_record) do
 
   ActiveRecord::Base.class_eval do
-    def self.simple_execute(sql_str, **sql_vars)
+    def self.simple_execute(sql_str, *sql_vars, **kwargs)
+      # If sql_str is an array, combine with sql_vars, then "re-divide"
+      sql_str, *sql_vars = sql_str.concat(sql_vars) if sql_str.is_a?(Array)
+      sql_vars << kwargs unless kwargs.empty?
+
       ### must use send because this method is private is Rails 5.1 only, Public in 5.0 and 5.2
-      sanitized_sql = ActiveRecord::Base.send(:sanitize_sql_array, [sql_str, **sql_vars])
+      sanitized_sql = ActiveRecord::Base.send(:sanitize_sql_array, [sql_str, *sql_vars])
 
       results = ActiveRecord::Base.connection.execute(sanitized_sql)
 

--- a/test/unit/active_record_simple_execute_test.rb
+++ b/test/unit/active_record_simple_execute_test.rb
@@ -11,7 +11,7 @@ class ActiveRecordSimpleExecuteTest < ActiveSupport::TestCase
   def test_exposes_version
     assert ActiveRecordSimpleExecute::VERSION.is_a?(String)
   end
-  
+
   def test_no_results
     sql = <<~SQL.squish
       SELECT * FROM posts WHERE posts.title = 'bar'
@@ -23,7 +23,7 @@ class ActiveRecordSimpleExecuteTest < ActiveSupport::TestCase
 
     assert_empty results
   end
-  
+
   def test_has_results
     Post.create!(title: "bar")
 
@@ -41,8 +41,8 @@ class ActiveRecordSimpleExecuteTest < ActiveSupport::TestCase
 
     assert_equal "bar", results.first["title"]
   end
-  
-  def test_with_sql_vars
+
+  def test_with_sql_kwargs
     Post.create!(title: "bar")
 
     sql = <<~SQL.squish
@@ -60,4 +60,57 @@ class ActiveRecordSimpleExecuteTest < ActiveSupport::TestCase
     assert_equal "bar", results.first["title"]
   end
 
+  def test_with_sql_vars
+    Post.create!(title: "bar")
+
+    sql = <<~SQL.squish
+      SELECT * FROM posts WHERE posts.title = ?
+    SQL
+
+    results = ActiveRecord::Base.simple_execute(sql, "bar")
+
+    assert_kind_of Array, results
+
+    assert_equal 1, results.size
+
+    assert_kind_of Hash, results.first
+
+    assert_equal "bar", results.first["title"]
+  end
+
+  def test_with_sql_array_kwargs
+    Post.create!(title: "bar")
+
+    sql = <<~SQL.squish
+      SELECT * FROM posts WHERE posts.title = :title
+    SQL
+
+    results = ActiveRecord::Base.simple_execute([sql, { title: "bar" }])
+
+    assert_kind_of Array, results
+
+    assert_equal 1, results.size
+
+    assert_kind_of Hash, results.first
+
+    assert_equal "bar", results.first["title"]
+  end
+
+  def test_with_sql_array_vars
+    Post.create!(title: "bar")
+
+    sql = <<~SQL.squish
+      SELECT * FROM posts WHERE posts.title = ?
+    SQL
+
+    results = ActiveRecord::Base.simple_execute([sql, "bar"])
+
+    assert_kind_of Array, results
+
+    assert_equal 1, results.size
+
+    assert_kind_of Hash, results.first
+
+    assert_equal "bar", results.first["title"]
+  end
 end


### PR DESCRIPTION
This allows us to pass positional arguments and not just keyword ones.