### PR TITLE
Switch from using Active Record `execute` method to `exec_query` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 - Unreleased - [View Diff](https://github.com/westonganger/active_record_simple_execute/compare/v0.9.1...master)
   * [#8](https://github.com/westonganger/active_record_simple_execute/pull/8) - Allow usage with different Active Record database connections
   * [#7](https://github.com/westonganger/active_record_simple_execute/pull/7) - Drop support for Rails 5.1 and below
+  * [#5](https://github.com/westonganger/active_record_simple_execute/pull/5) - Switch from using Active Record `execute` method to `exec_query` method for better memory management
 
 - v0.9.1 - Feb 13, 2023 - [View Diff](https://github.com/westonganger/active_record_simple_execute/compare/v0.9.0...v0.9.1)
   * [#1](https://github.com/westonganger/active_record_simple_execute/pull/1) - Utilize active_record lazy loading

--- a/Rakefile
+++ b/Rakefile
@@ -10,12 +10,3 @@ Rake::TestTask.new(:test) do |t|
 end
 
 task default: [:test]
-
-task :console do
-  require 'active_record_simple_execute'
-
-  require 'test/dummy_app/app/models/post'
-
-  require 'irb'
-  binding.irb
-end

--- a/lib/active_record_simple_execute.rb
+++ b/lib/active_record_simple_execute.rb
@@ -8,25 +8,9 @@ ActiveSupport.on_load(:active_record) do
     def simple_execute(sql_str, **sql_vars)
       sanitized_sql = ActiveRecord::Base.sanitize_sql_array([sql_str, **sql_vars])
 
-      results = self.execute(sanitized_sql)
+      query_result = exec_query(sanitized_sql)
 
-      if defined?(PG::Result) && results.is_a?(PG::Result)
-        records = results.to_a
-      elsif defined?(Mysql2::Result) && results.is_a?(Mysql2::Result)
-        records = []
-
-        results.each do |row|
-          h = {}
-
-          results.fields.each_with_index do |field,i|
-            h[field] = row[i]
-          end
-
-          records << h
-        end
-      else
-        records = results
-      end
+      records = query_result.to_a
 
       return records
     end

--- a/test/unit/active_record_simple_execute_test.rb
+++ b/test/unit/active_record_simple_execute_test.rb
@@ -21,7 +21,7 @@ class ActiveRecordSimpleExecuteTest < ActiveSupport::TestCase
       SELECT * FROM posts WHERE posts.title = 'bar'
     SQL
 
-    results = ActiveRecord::Base.simple_execute(sql)
+    results = ActiveRecord::Base.connection.simple_execute(sql)
 
     assert_kind_of Array, results
 
@@ -35,7 +35,7 @@ class ActiveRecordSimpleExecuteTest < ActiveSupport::TestCase
       SELECT * FROM posts WHERE posts.title = 'bar'
     SQL
 
-    results = ActiveRecord::Base.simple_execute(sql)
+    results = ActiveRecord::Base.connection.simple_execute(sql)
 
     assert_kind_of Array, results
 
@@ -53,7 +53,7 @@ class ActiveRecordSimpleExecuteTest < ActiveSupport::TestCase
       SELECT * FROM posts WHERE posts.title = :title
     SQL
 
-    results = ActiveRecord::Base.simple_execute(sql, title: "bar")
+    results = ActiveRecord::Base.connection.simple_execute(sql, title: "bar")
 
     assert_kind_of Array, results
 
@@ -86,11 +86,7 @@ class ActiveRecordSimpleExecuteTest < ActiveSupport::TestCase
 
     results = ActiveRecord::Base.simple_execute(sql, old_title: "some-old-title", new_title: "some-new-title")
 
-    if mysql?
-      assert_equal results, nil
-    else
-      assert_equal results, []
-    end
+    assert_equal results, []
 
     assert_equal Post.where(title: "some-new-title").size, 1
   end
@@ -127,11 +123,7 @@ class ActiveRecordSimpleExecuteTest < ActiveSupport::TestCase
 
     results = ActiveRecord::Base.simple_execute(sql, title: "bar")
 
-    if mysql?
-      assert_equal results, nil
-    else
-      assert_equal results, []
-    end
+    assert_equal results, []
 
     assert_equal Post.all.size, 0
   end


### PR DESCRIPTION
According to the following we need to manually memory manage with the `pg` gem and the `execute` method

- https://stackoverflow.com/questions/33248364/should-pgresultclear-be-called-after-youve-executed-raw-sql
- https://deveiate.org/code/pg/PG/Result.html#method-i-clear
- https://www.reddit.com/r/rails/comments/1g41qdn/activerecordbaseconnectionexecuteraw_sql_causing/

So we switch to the Active Record `exec_query` method instead which always handles the memory management for us.