### PR TITLE
Allow usage with different Active Record database connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 ---------
 
 - Unreleased - [View Diff](https://github.com/westonganger/active_record_simple_execute/compare/v0.9.1...master)
+  * [#8](https://github.com/westonganger/active_record_simple_execute/pull/8) - Allow usage with different Active Record database connections
   * [#7](https://github.com/westonganger/active_record_simple_execute/pull/7) - Drop support for Rails 5.1 and below
 
 - v0.9.1 - Feb 13, 2023 - [View Diff](https://github.com/westonganger/active_record_simple_execute/compare/v0.9.0...v0.9.1)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ sql_str = <<~SQL.squish
   WHERE orders.company_id = :company_id AND orders.updated_by_user_id = :user_id
 SQL
 
-records = ActiveRecord::Base.simple_execute(sql_str, company_id: @company.id, user_id: @user.id)
+records = ActiveRecord::Base.connection.simple_execute(sql_str, company_id: @company.id, user_id: @user.id)
+# OR use the convenience method excluding the connection portion
+# ActiveRecord::Base.simple_execute(...)
 ```
 
 ### Using Plain ActiveRecord Syntax

--- a/lib/active_record_simple_execute.rb
+++ b/lib/active_record_simple_execute.rb
@@ -4,11 +4,11 @@ require "active_support/lazy_load_hooks"
 
 ActiveSupport.on_load(:active_record) do
 
-  ActiveRecord::Base.class_eval do
-    def self.simple_execute(sql_str, **sql_vars)
+  ActiveRecord::ConnectionAdapters::DatabaseStatements.module_eval do
+    def simple_execute(sql_str, **sql_vars)
       sanitized_sql = ActiveRecord::Base.sanitize_sql_array([sql_str, **sql_vars])
 
-      results = ActiveRecord::Base.connection.execute(sanitized_sql)
+      results = self.execute(sanitized_sql)
 
       if defined?(PG::Result) && results.is_a?(PG::Result)
         records = results.to_a
@@ -29,6 +29,12 @@ ActiveSupport.on_load(:active_record) do
       end
 
       return records
+    end
+  end
+
+  ActiveRecord::Base.class_eval do
+    def self.simple_execute(sql_str, **sql_vars)
+      self.connection.simple_execute(sql_str, **sql_vars)
     end
   end
 

--- a/test/unit/active_record_simple_execute_test.rb
+++ b/test/unit/active_record_simple_execute_test.rb
@@ -157,4 +157,28 @@ class ActiveRecordSimpleExecuteTest < ActiveSupport::TestCase
     assert_equal Post.all.size, 0
   end
 
+  def test_activerecord_base_method
+    Post.create!(title: "bar")
+
+    sql = <<~SQL.squish
+      SELECT * FROM posts WHERE posts.title = 'bar'
+    SQL
+
+    results = ActiveRecord::Base.simple_execute(sql)
+
+    assert_equal 1, results.size
+  end
+
+  def test_connection_method
+    Post.create!(title: "bar")
+
+    sql = <<~SQL.squish
+      SELECT * FROM posts WHERE posts.title = 'bar'
+    SQL
+
+    results = ActiveRecord::Base.connection.simple_execute(sql)
+
+    assert_equal 1, results.size
+  end
+
 end


### PR DESCRIPTION
Allow usage on multi-database configurations or when using Active Record `with_connection` method