### PR TITLE
Automatically switch between select_all and exec_query based on if query is read or write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 ---------
 
 - Unreleased - [View Diff](https://github.com/westonganger/active_record_simple_execute/compare/v1.0.0...master)
-  * Nothing yet
+  * [#9](https://github.com/westonganger/active_record_simple_execute/pull/9) - Automatically switch between `select_all` and `exec_query` based on if query is read or write, update readme examples with new knowledge around `Arel.sql` vs `sanitize_sql_array`
 
 - v1.0.0 - Oct 17, 2024 - [View Diff](https://github.com/westonganger/active_record_simple_execute/compare/v0.9.1...v1.0.0)
   * [#8](https://github.com/westonganger/active_record_simple_execute/pull/8) - Allow usage with different Active Record database connections

--- a/lib/active_record_simple_execute.rb
+++ b/lib/active_record_simple_execute.rb
@@ -6,9 +6,21 @@ ActiveSupport.on_load(:active_record) do
 
   ActiveRecord::ConnectionAdapters::DatabaseStatements.module_eval do
     def simple_execute(sql_str, **sql_vars)
-      sanitized_sql = ActiveRecord::Base.sanitize_sql_array([sql_str, **sql_vars])
+      readonly = sql_str.strip.downcase.start_with?("select ")
 
-      query_result = exec_query(sanitized_sql)
+      if readonly
+        if Rails::VERSION::STRING.to_f >= 7.1
+          sanitized_sql = Arel.sql(sql_str, **sql_vars)
+        else
+          sanitized_sql = ActiveRecord::Base.sanitize_sql_array([sql_str, **sql_vars])
+        end
+        query_result = select_all(sanitized_sql)
+      else
+        # Must use sanitize_sql_array, since Arel.sql is not yet compatible with `exec_query` or `execute`, https://github.com/rails/rails/pull/53740
+
+        sanitized_sql = ActiveRecord::Base.sanitize_sql_array([sql_str, **sql_vars])
+        query_result = exec_query(sanitized_sql)
+      end
 
       records = query_result.to_a
 

--- a/test/dummy_app/config/application.rb
+++ b/test/dummy_app/config/application.rb
@@ -3,7 +3,7 @@ require File.expand_path('../boot', __FILE__)
 begin
   require 'warning'
   Warning.ignore(
-    %r{mail/parsers/address_lists_parser}, ### Hide mail gem warnings
+    %r{mail/parsers}, ### Hide mail gem warnings
   )
 rescue LoadError
   # Do nothing

--- a/test/unit/active_record_simple_execute_test.rb
+++ b/test/unit/active_record_simple_execute_test.rb
@@ -70,7 +70,7 @@ class ActiveRecordSimpleExecuteTest < ActiveSupport::TestCase
       VALUES (:title, :created_at, :updated_at)
     SQL
 
-    results = ActiveRecord::Base.simple_execute(sql, title: "some-new-title", created_at: Time.now, updated_at: Time.now)
+    ActiveRecord::Base.simple_execute(sql, title: "some-new-title", created_at: Time.now, updated_at: Time.now)
 
     assert_equal Post.where(title: "some-new-title").size, 1
   end


### PR DESCRIPTION
- Automatically switch between `select_all` and `exec_query` based on if query is read or write
- Update readme examples with new knowledge around `Arel.sql` vs `sanitize_sql_array`